### PR TITLE
feat: add API version prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Prefix all API routes with `/api/v1` and update clients and documentation accordingly.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Depends,Request, Response
+from fastapi import APIRouter, Depends, FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from prometheus_fastapi_instrumentator import Instrumentator
@@ -74,16 +74,18 @@ app.add_middleware(MaxBodySizeMiddleware, max_body_size=10 * 1024 * 1024)
 
 
 # routes
-app.include_router(auth_router)
-app.include_router(auth_me_router)
-app.include_router(admin_routes)
-app.include_router(crops_router)
-app.include_router(media_router)
-app.include_router(contact_router)
-app.include_router(rating_routes)
-app.include_router(order_routes)
-app.include_router(auth_social_router)
-app.include_router(favorites_routes)
-app.include_router(chat_routes)
-app.include_router(ws_routes)
+api_router = APIRouter(prefix="/api/v1")
+api_router.include_router(auth_router)
+api_router.include_router(auth_me_router)
+api_router.include_router(admin_routes)
+api_router.include_router(crops_router)
+api_router.include_router(media_router)
+api_router.include_router(contact_router)
+api_router.include_router(rating_routes)
+api_router.include_router(order_routes)
+api_router.include_router(auth_social_router)
+api_router.include_router(favorites_routes)
+api_router.include_router(chat_routes)
+api_router.include_router(ws_routes)
+app.include_router(api_router)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,11 +1,11 @@
 # Mahaseel API Documentation
 
-Base URL: `https://staging.mahaseel.com`
+Base URL: `https://staging.mahaseel.com/api/v1`
 
 ## Authentication
 
 ### Register
-`POST /auth/register`
+`POST /api/v1/auth/register`
 
 ```json
 {
@@ -14,18 +14,18 @@ Base URL: `https://staging.mahaseel.com`
 }
 Login
 
-POST /auth/login
+POST /api/v1/auth/login
 
 Returns JWT after OTP verification.
 
 Crops
 List Crops
 
-GET /crops?page=1&limit=20
+GET /api/v1/crops?page=1&limit=20
 
 Create Crop
 
-POST /crops
+POST /api/v1/crops
 
 {
   "name": "طماطم",
@@ -39,7 +39,7 @@ POST /crops
 
 Orders
 
-POST /orders
+POST /api/v1/orders
 
 {
   "crop_id": 1,
@@ -49,7 +49,7 @@ POST /orders
 
 Ratings
 
-POST /ratings
+POST /api/v1/ratings
 
 {
   "seller_id": 2,
@@ -58,7 +58,7 @@ POST /ratings
 
 Media Upload
 
-POST /media (multipart/form-data)
+POST /api/v1/media (multipart/form-data)
 
 
 3. Link to your live Swagger/OpenAPI UI:

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,7 @@
+# Migration Notes
+
+## API v1 Prefix
+
+- All API routes are now served under `/api/v1`.
+- Update client base URLs to include the new prefix, e.g. `https://staging.mahaseel.com/api/v1`.
+- System endpoints like `/healthz` remain at the root.

--- a/mobile/lib/services/api_client.dart
+++ b/mobile/lib/services/api_client.dart
@@ -26,7 +26,7 @@ class ApiClient {
     final baseUrl = dotenv.env['API_BASE_URL'] ?? 'http://127.0.0.1:8000';
 
     dio = Dio(BaseOptions(
-      baseUrl: baseUrl,
+      baseUrl: '$baseUrl/api/v1',
       connectTimeout: const Duration(seconds: 15),
       receiveTimeout: const Duration(seconds: 20),
       responseType: ResponseType.json,


### PR DESCRIPTION
## Summary
- namespace backend routers under `/api/v1`
- adjust mobile ApiClient and docs for new API base path
- document migration and changelog entry

## Testing
- `pytest` *(fails: NameError: name 'pytest' is not defined)*
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b34a3923e48331b228adf2d3205170