### PR TITLE
Add JWT secret requirement and token service

### DIFF
--- a/backend/app/core/__init__.py
+++ b/backend/app/core/__init__.py
@@ -1,4 +1,5 @@
-from . import config
-from . import logging_conf
-from . import otp_store
-from . import security
+from . import config as config
+from . import logging_conf as logging_conf
+from . import otp_store as otp_store
+from . import security as security
+from . import token_service as token_service

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -5,11 +5,12 @@ from datetime import timedelta
 from typing import List
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
-from pydantic import AnyHttpUrl, field_validator
+from pydantic import AnyHttpUrl, Field, field_validator
 
 
 def _normalize_db_url(url: str) -> str:
-    if not url: return url
+    if not url:
+        return url
     url = url.strip()
     # keep if already using postgresql+psycopg://
     if url.startswith("postgres://"):
@@ -25,15 +26,15 @@ class Settings(BaseSettings):
     api_host: str = "0.0.0.0"
     api_port: int = 8000
 
-    jwt_secret: str = "CHANGE_ME_DEV_ONLY"
+    jwt_secret: str = Field(..., env="JWT_SECRET")
     jwt_algorithm: str = "HS256"
     jwt_access_minutes: int = 60
+    jwt_refresh_days: int = 7
 
-    google_client_id: str = ""    
+    google_client_id: str = ""
     fb_app_id: str = ""
     fb_app_secret: str = ""
 
-    
     # Local default (host-run)
     database_url: str = "postgresql+psycopg://mahaseel:mahaseel@localhost:5432/mahaseel"
 
@@ -63,6 +64,10 @@ class Settings(BaseSettings):
         return timedelta(minutes=self.jwt_access_minutes)
 
     @property
+    def refresh_expires(self) -> timedelta:
+        return timedelta(days=self.jwt_refresh_days)
+
+    @property
     def effective_database_url(self) -> str:
         """
         Priority:
@@ -83,8 +88,8 @@ class Settings(BaseSettings):
         return _normalize_db_url(self.effective_database_url)
 
     def validate_for_runtime(self) -> None:
-        if not self.is_dev and self.jwt_secret == "CHANGE_ME_DEV_ONLY":
-            raise RuntimeError("Unsafe JWT secret in non-dev environment")
+        if not self.jwt_secret:
+            raise RuntimeError("JWT secret is not configured")
 
 
 settings = Settings()

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,21 +1,23 @@
-from datetime import datetime, timedelta, timezone
-from jose import jwt
 from typing import Any, Optional
-from app.core.config import settings
 
-def create_access_token(subject: str | int,role: str, extra: Optional[dict[str, Any]] = None) -> str:
-    now = datetime.now(tz=timezone.utc)
-    payload: dict[str, Any] = {
-        "sub": str(subject),
-        "iat": int(now.timestamp()),
-        "exp": int((now + settings.access_expires).timestamp()),
-        "typ": "access",
-        "role": role,
+from app.core.token_service import token_service
 
-    }
-    if extra:
-        payload.update(extra)
-    return jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
+
+def create_access_token(
+    subject: str | int, role: str, extra: Optional[dict[str, Any]] = None
+) -> str:
+    return token_service.create_access_token(subject, role, extra)
+
+
+def create_refresh_token(
+    subject: str | int, role: str, extra: Optional[dict[str, Any]] = None
+) -> str:
+    return token_service.create_refresh_token(subject, role, extra)
+
 
 def decode_token(token: str) -> dict[str, Any]:
-    return jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
+    return token_service.decode(token)
+
+
+def revoke_token(token: str) -> None:
+    token_service.revoke(token)

--- a/backend/app/core/token_service.py
+++ b/backend/app/core/token_service.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+from uuid import uuid4
+
+from jose import jwt
+
+from app.core.config import settings
+
+
+class TokenService:
+    """Service for creating and managing JWT tokens."""
+
+    def __init__(self) -> None:
+        # maps jti -> expiration datetime
+        self._revoked: dict[str, datetime] = {}
+
+    # ------------------------------------------------------------------
+    # internal helpers
+    def _purge(self) -> None:
+        """Remove expired entries from the revocation list."""
+        now = datetime.now(tz=timezone.utc)
+        expired = [jti for jti, exp in self._revoked.items() if exp <= now]
+        for jti in expired:
+            del self._revoked[jti]
+
+    def _create_token(
+        self,
+        subject: str | int,
+        role: str,
+        expires_delta,
+        typ: str,
+        extra: Optional[dict[str, Any]] = None,
+    ) -> str:
+        now = datetime.now(tz=timezone.utc)
+        jti = str(uuid4())
+        payload: dict[str, Any] = {
+            "sub": str(subject),
+            "iat": int(now.timestamp()),
+            "exp": int((now + expires_delta).timestamp()),
+            "typ": typ,
+            "jti": jti,
+            "role": role,
+        }
+        if extra:
+            payload.update(extra)
+        return jwt.encode(
+            payload, settings.jwt_secret, algorithm=settings.jwt_algorithm
+        )
+
+    # ------------------------------------------------------------------
+    # public API
+    def create_access_token(
+        self, subject: str | int, role: str, extra: Optional[dict[str, Any]] = None
+    ) -> str:
+        return self._create_token(
+            subject, role, settings.access_expires, "access", extra
+        )
+
+    def create_refresh_token(
+        self, subject: str | int, role: str, extra: Optional[dict[str, Any]] = None
+    ) -> str:
+        return self._create_token(
+            subject, role, settings.refresh_expires, "refresh", extra
+        )
+
+    def decode(self, token: str) -> dict[str, Any]:
+        payload = jwt.decode(
+            token, settings.jwt_secret, algorithms=[settings.jwt_algorithm]
+        )
+        jti = payload.get("jti")
+        if jti and self.is_revoked(jti):
+            raise RuntimeError("Token has been revoked")
+        return payload
+
+    def revoke(self, token: str) -> None:
+        payload = jwt.decode(
+            token, settings.jwt_secret, algorithms=[settings.jwt_algorithm]
+        )
+        jti = payload.get("jti")
+        if not jti:
+            return
+        exp = datetime.fromtimestamp(payload["exp"], tz=timezone.utc)
+        self._revoked[jti] = exp
+        self._purge()
+
+    def is_revoked(self, jti: str) -> bool:
+        self._purge()
+        return jti in self._revoked
+
+
+# Shared singleton instance
+token_service = TokenService()

--- a/backend/tests/test_token_service.py
+++ b/backend/tests/test_token_service.py
@@ -1,0 +1,13 @@
+import pytest
+
+from app.core.token_service import token_service
+
+
+def test_refresh_token_and_revocation():
+    refresh = token_service.create_refresh_token("user", "role")
+    payload = token_service.decode(refresh)
+    assert payload["typ"] == "refresh"
+
+    token_service.revoke(refresh)
+    with pytest.raises(RuntimeError):
+        token_service.decode(refresh)

--- a/docs/secret-rotation.md
+++ b/docs/secret-rotation.md
@@ -1,0 +1,23 @@
+# JWT Secret Rotation
+
+Mahaseel relies on the `JWT_SECRET` environment variable for signing
+JSON Web Tokens. For security, rotate this secret periodically.
+
+## Generate a new secret
+
+```bash
+python - <<'PY'
+import secrets
+print(secrets.token_urlsafe(32))
+PY
+```
+
+## Rotation steps
+
+1. Deploy the new value as `JWT_SECRET` alongside the old one.
+2. Restart the application with the new secret.
+3. Revoke existing refresh tokens via the revocation list in
+   `app/core/token_service.py` to force users to re‑authenticate.
+
+Old tokens signed with the previous secret will become invalid once the
+application restarts with the new secret.


### PR DESCRIPTION
## Summary
- enforce `JWT_SECRET` environment variable and remove insecure default
- implement refresh tokens with revocation list
- document JWT secret rotation

## Testing
- `ruff check backend/app/core/__init__.py backend/app/core/security.py backend/app/core/token_service.py backend/app/core/config.py backend/tests/test_token_service.py`
- `cd backend && JWT_SECRET=testsecret pytest -q` *(fails: AttributeError: module 'app.core.otp_store' has no attribute '_store')*

------
https://chatgpt.com/codex/tasks/task_e_68b34a39a208833191ba2f01644c3624