### PR TITLE
feat: enforce HTTPS API base URL

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -14,3 +14,16 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## API configuration
+
+The app reads its API endpoint from a runtime environment variable using
+[`flutter_dotenv`](https://pub.dev/packages/flutter_dotenv).
+Create a `.env` file in the `mobile/` directory:
+
+```
+API_BASE_URL=https://staging.mahaseel.com
+```
+
+- `API_BASE_URL` – Base URL for HTTP requests. In release builds the app
+  refuses to run if this value is not HTTPS.

--- a/mobile/lib/services/api_client.dart
+++ b/mobile/lib/services/api_client.dart
@@ -2,6 +2,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter/foundation.dart';
 import 'logging_interceptor.dart';
 
 class ApiClient {
@@ -23,7 +24,11 @@ class ApiClient {
     if (_initialized) return;
     _initialized = true;
 
-    final baseUrl = dotenv.env['API_BASE_URL'] ?? 'http://127.0.0.1:8000';
+    final baseUrl =
+        dotenv.env['API_BASE_URL'] ?? 'https://staging.mahaseel.com';
+    if (kReleaseMode && !baseUrl.startsWith('https://')) {
+      throw StateError('API_BASE_URL must use HTTPS in release builds');
+    }
 
     dio = Dio(BaseOptions(
       baseUrl: baseUrl,


### PR DESCRIPTION
## Summary
- default API client to staging HTTPS endpoint
- guard against non-HTTPS API_BASE_URL in release builds
- document API_BASE_URL env config

## Testing
- `cd mobile && flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b34a43cc148331a80b1b1ffd649796